### PR TITLE
Add asserts for Stripe Day5 test

### DIFF
--- a/Stripe/Easy/Day5.cpp
+++ b/Stripe/Easy/Day5.cpp
@@ -33,8 +33,8 @@ int consecutiveRun(int n)
 
 int main()
 {
-    int n = 156;
-
-    cout << "Length of the longest consecutive run of 1s: " << consecutiveRun(n);
+    assert(consecutiveRun(156) == 3);
+    assert(consecutiveRun(0) == 0);
+    cout << "All tests passed." << endl;
     return 0;
 }


### PR DESCRIPTION
## Summary
- add small assert-based test harness to Stripe Day5 solution
- ensure newline at EOF

## Testing
- `g++ -std=c++17 Stripe/Easy/Day5.cpp && ./a.out`

------
https://chatgpt.com/codex/tasks/task_e_6845c275d9e48331ab7c2fac142d2c31